### PR TITLE
chore: there are no ui tests, we should exit 0. 

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,7 @@
     "lint-check": "eslint '**/*.{js,jsx}'",
     "lint-fix": "eslint --fix '**/*.{js,jsx}'",
     "start": "react-scripts start",
-    "test": "react-scripts test --env=jsdom",
+    "test": "exit 0",
     "build": "react-scripts build",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
chore: there are no ui tests, we should exit 0. Fixes erroring in agoric-sdk CI where exits with 1 if no tests